### PR TITLE
Add support for nullish amount

### DIFF
--- a/dist/QRPayment.d.ts
+++ b/dist/QRPayment.d.ts
@@ -3,7 +3,7 @@ export declare class QRPayment {
     readonly paymentOptions: PaymentOptions;
     readonly account: Account;
     readonly payment: Payment;
-    constructor(amount: number, bankAccount: Account | string, paymentOptions?: Partial<PaymentOptions>);
+    constructor(amount: number | null, bankAccount: Account | string, paymentOptions?: Partial<PaymentOptions>);
     getSvg(): string;
     getQrContent(): string;
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -17,7 +17,7 @@ export interface Account {
  * @property {string} currency - The currency type (limited to 'CZK').
  */
 export interface Payment {
-    readonly amount: string;
+    readonly amount: string | null;
     readonly currency: string;
 }
 /**

--- a/dist/validation/schema.d.ts
+++ b/dist/validation/schema.d.ts
@@ -24,13 +24,13 @@ export declare const PaymentOptionsSchema: z.ZodObject<{
     URL?: string | undefined;
 }>;
 export declare const PaymentSchema: z.ZodEffects<z.ZodObject<{
-    amount: z.ZodEffects<z.ZodEffects<z.ZodNumber, string, number>, string, number>;
+    amount: z.ZodNullable<z.ZodEffects<z.ZodEffects<z.ZodNumber, string, number>, string, number>>;
 }, "strip", z.ZodTypeAny, {
-    amount: string;
+    amount: string | null;
 }, {
-    amount: number;
+    amount: number | null;
 }>, Payment, {
-    amount: number;
+    amount: number | null;
 }>;
 export declare const AccountSchema: z.ZodEffects<z.ZodObject<{
     prefix: z.ZodString;

--- a/dist/validation/schema.js
+++ b/dist/validation/schema.js
@@ -40,7 +40,8 @@ exports.PaymentSchema = zod_1.z
         .number()
         .min(1, 'Minimum value is 1')
         .transform((amount) => amount.toFixed(2))
-        .refine((val) => val.length <= 10, 'Invalid amount'),
+        .refine((val) => val.length <= 10, 'Invalid amount')
+        .nullable(),
 })
     .transform((data) => ({
     ...data,

--- a/src/QRPayment.spec.ts
+++ b/src/QRPayment.spec.ts
@@ -42,6 +42,22 @@ describe('QRPayment', () => {
         VS: '126303',
       });
     });
+
+    it('without amount', () => {
+      const qrPayment = new QRPayment(null, '19-2000145399/0800', {
+        VS: '126303',
+        message: 'Payment for order #126303',
+      });
+
+      expect(qrPayment.payment.amount).toEqual(null);
+      expect(qrPayment.account.prefix).toEqual('000019');
+      expect(qrPayment.account.number).toEqual('2000145399');
+      expect(qrPayment.account.bankCode).toEqual('0800');
+      expect(qrPayment.paymentOptions).toMatchObject({
+        message: 'Payment for order #126303',
+        VS: '126303',
+      });
+    });
   });
 
   describe('generates content for QR code', () => {
@@ -60,7 +76,7 @@ describe('QRPayment', () => {
       );
 
       expect(qrPayment.getQrContent()).toEqual(
-        'SPD*1.0*ACC:CZ6508000000192000145399*AM:156.90*CC:CZK*MSG:Payment for order #126303*X-VS:126303',
+        'SPD*1.0*ACC:CZ6508000000192000145399*CC:CZK*AM:156.90*MSG:Payment for order #126303*X-VS:126303',
       );
     });
 
@@ -71,7 +87,18 @@ describe('QRPayment', () => {
       });
 
       expect(qrPayment.getQrContent()).toEqual(
-        'SPD*1.0*ACC:CZ6508000000192000145399*AM:156.90*CC:CZK*MSG:Payment for order #126303*X-VS:126303',
+        'SPD*1.0*ACC:CZ6508000000192000145399*CC:CZK*AM:156.90*MSG:Payment for order #126303*X-VS:126303',
+      );
+    });
+
+    it('without amount', () => {
+      const qrPayment = new QRPayment(null, '19-2000145399/0800', {
+        VS: '126303',
+        message: 'Payment for order #126303',
+      });
+
+      expect(qrPayment.getQrContent()).toEqual(
+        'SPD*1.0*ACC:CZ6508000000192000145399*CC:CZK*MSG:Payment for order #126303*X-VS:126303',
       );
     });
   });

--- a/src/QRPayment.ts
+++ b/src/QRPayment.ts
@@ -14,7 +14,7 @@ export class QRPayment {
   public readonly payment: Payment;
 
   constructor(
-    amount: number,
+    amount: number | null,
     bankAccount: Account | string,
     paymentOptions: Partial<PaymentOptions> = {},
   ) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export interface Account {
  * @property {string} currency - The currency type (limited to 'CZK').
  */
 export interface Payment {
-  readonly amount: string;
+  readonly amount: string | null;
   readonly currency: string;
 }
 

--- a/src/qr/qr.spec.ts
+++ b/src/qr/qr.spec.ts
@@ -17,7 +17,7 @@ describe('qr', () => {
       URL: 'www.google.com',
     };
     expect(generateQrContent(iban, payment, paymentOptions)).toEqual(
-      'SPD*1.0*ACC:CZ2130300000001263035066*AM:199.90*CC:CZK*MSG:Poznamka*X-VS:123*X-SS:321*X-KS:456*X-URL:www.google.com*DT:20230408',
+      'SPD*1.0*ACC:CZ2130300000001263035066*CC:CZK*AM:199.90*MSG:Poznamka*X-VS:123*X-SS:321*X-KS:456*X-URL:www.google.com*DT:20230408',
     );
   });
 });

--- a/src/qr/qr.ts
+++ b/src/qr/qr.ts
@@ -8,9 +8,12 @@ export const generateQrContent = (
 ): string => {
   const content = new Map<string, string>([
     ['ACC', iban],
-    ['AM', payment.amount],
     ['CC', payment.currency],
   ]);
+
+  if (payment.amount) {
+    content.set('AM', payment.amount);
+  }
 
   if (options.message) {
     content.set('MSG', options.message);

--- a/src/validation/schema.ts
+++ b/src/validation/schema.ts
@@ -68,7 +68,8 @@ export const PaymentSchema = z
       .number()
       .min(1, 'Minimum value is 1')
       .transform((amount: number) => amount.toFixed(2))
-      .refine((val: string) => val.length <= 10, 'Invalid amount'),
+      .refine((val: string) => val.length <= 10, 'Invalid amount')
+      .nullable(),
   })
   .transform(
     (data): Payment => ({


### PR DESCRIPTION
This PR allows amount to be `null`. It also adds tests for this case.

This adheres to the [specification](https://qr-platba.cz/pro-vyvojare/specifikace-formatu/) where "AM" attribute is non-mandatory. Some banks also allow generating QR codes without amount. From my personal testing, Fio Bank mobile app allows it.

Alternatively, setting the amount to zero instead of null is also acceptable for my project, but I find this solution cleaner. Maybe it would be nice to allow both.